### PR TITLE
Faltava implementar o GetInstance

### DIFF
--- a/src/ACBr.Net.Core.Shared/InteropServices/ACBrLPStr.cs
+++ b/src/ACBr.Net.Core.Shared/InteropServices/ACBrLPStr.cs
@@ -66,6 +66,15 @@ namespace ACBr.Net.Core.InteropServices
             return IntPtr.Size;
         }
 
+        public static ICustomMarshaler GetInstance(string cookie)
+        {
+            if (static_instance == null)
+            {
+                return static_instance = new ACBrLPStr();
+            }
+            return static_instance;
+        }
+        
         #endregion Methods
     }
 }


### PR DESCRIPTION
Sem o método GetInstance o retorno dá erro em alguns casos de chamada de biblioteca de 64 bit