### PR TITLE
Falta de instanciar a variável methodCache

### DIFF
--- a/src/ACBr.Net.Core.Shared/InteropServices/ACBrSafeHandle.cs
+++ b/src/ACBr.Net.Core.Shared/InteropServices/ACBrSafeHandle.cs
@@ -205,6 +205,7 @@ namespace ACBr.Net.Core.InteropServices
             : base(IntPtr.Zero, true)
         {
             methodList = new Dictionary<Type, string>();
+            methodCache = new Dictionary<string, Delegate>();
             className = GetType().Name;
 
             var pNewSession = LibLoader.LoadLibrary(dllPath);


### PR DESCRIPTION
quando não iniciamos a variável methodCache dá um erro, pois no código é feito um contains nela e quando ela está nula o contains dá um erro pois a variável não foi iniciada